### PR TITLE
Fix for the description of -Wvla

### DIFF
--- a/vla.md
+++ b/vla.md
@@ -5,7 +5,7 @@ is an array where the size is not constant and depends on a variable.
 
 VLAs have poor compiler support and can lead to inefficient code.
 The core issue with VLAs is that the compiler doesn't know the size of the stack frame.
-Without warning flags like `-Wvla` (turned on by `-Wall`) it can be easy to create a VLA by
+Without warning flags like `-Wvla` (turned on by `-Wpedantic`) it can be easy to create a VLA by
 accident, even in C++ with some compilers.
 
 ## Compiler Support


### PR DESCRIPTION
This fix explicitly shows how -Wvla can be activated by other parameters

tested with the online tool godbolt.org:

source code:
```
void awoo(int x) {
	int arr[x];
}
```

compilers used:
x86-64 gcc 5.1
x86-64 clang 3.2

compiler arguments passed: 
-Wpedantic